### PR TITLE
Ajout d'un script pour capturer et sauvegarder des captures d'écran du Frame Buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /resources_compiled
 /_bin
 /assetc-ubuntu-x64-2.3.0
+screenshots/.png

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
 			"stopOnEntry": false,
 			"program": "${file}",
 			"cwd": "${workspaceFolder}/",
-			"luaexe": "d:/harfang/hg_lua/lua.exe",
+			"luaexe": "C:/works/Harfang/lua/hg_lua-win-x64-3.2.7/lua.exe",
 		},
 		{
 			"name": "Go: Current file",

--- a/scene_capture_texture.lua
+++ b/scene_capture_texture.lua
@@ -46,7 +46,7 @@ while not hg.ReadKeyboard():Key(hg.K_Escape) and hg.IsWindowOpen(win) do
     scene:Update(dt)
 
     trs = scene:GetNode('engine_master'):GetTransform()
-	trs:SetRot(trs:GetRot() + hg.Vec3(0, hg.Deg(15) * hg.time_to_sec_f(dt), 0))
+    trs:SetRot(trs:GetRot() + hg.Vec3(0, hg.Deg(15) * hg.time_to_sec_f(dt), 0))
 
     view_id = 0
     view_id, pass_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), true, pipeline, res, frame_buffer.handle)
@@ -57,8 +57,7 @@ while not hg.ReadKeyboard():Key(hg.K_Escape) and hg.IsWindowOpen(win) do
     val_uniforms = {hg.MakeUniformSetValue('color', hg.Vec4(1, 1, 1, 1))}
     tex_uniforms = {hg.MakeUniformSetTexture('s_tex', tex_color, 0)}
 
-    hg.DrawModel(view_id, plane_mdl, plane_prg, val_uniforms, tex_uniforms,
-        hg.TransformationMat4(hg.Vec3(0, 0, 0), hg.Vec3(math.pi / 2, 0, math.pi)))
+    hg.DrawModel(view_id, plane_mdl, plane_prg, val_uniforms, tex_uniforms, hg.TransformationMat4(hg.Vec3(0, 0, 0), hg.Vec3(math.pi / 2, 0, math.pi)))
 
     -- Change state to capture when user press Space and Capture is not already running
     if (hg.ReadKeyboard():Key(hg.K_Space) and state == "none") then

--- a/scene_capture_texture.lua
+++ b/scene_capture_texture.lua
@@ -5,7 +5,7 @@ hg.InputInit()
 hg.WindowSystemInit()
 
 res_x, res_y, tex_size = 1024, 1024, 1024
-win = hg.RenderInit('Frame Buffer Screenshot', res_x, res_y, hg.RF_VSync | hg.RF_MSAA4X)
+win = hg.RenderInit('Scene Capture Texture', res_x, res_y, hg.RF_VSync | hg.RF_MSAA4X)
 
 -- Link precompiled assets folder to the project
 hg.AddAssetsFolder("resources_compiled")

--- a/scene_capture_texture.lua
+++ b/scene_capture_texture.lua
@@ -5,7 +5,7 @@ hg.InputInit()
 hg.WindowSystemInit()
 
 res_x, res_y, tex_size = 1024, 1024, 1024
-win = hg.RenderInit('Scene Capture Texture', res_x, res_y, hg.RF_VSync | hg.RF_MSAA4X)
+win = hg.RenderInit('Scene Capture Texture - Press SpaceBar to capture', res_x, res_y, hg.RF_VSync | hg.RF_MSAA4X)
 
 -- Link precompiled assets folder to the project
 hg.AddAssetsFolder("resources_compiled")
@@ -79,4 +79,3 @@ end
 
 hg.RenderShutdown()
 hg.DestroyWindow(win)
-

--- a/scene_capture_texture.lua
+++ b/scene_capture_texture.lua
@@ -49,7 +49,7 @@ while not hg.ReadKeyboard():Key(hg.K_Escape) and hg.IsWindowOpen(win) do
 	trs:SetRot(trs:GetRot() + hg.Vec3(0, hg.Deg(15) * hg.time_to_sec_f(dt), 0))
 
     view_id = 0
-    view_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), true, pipeline, res, frame_buffer.handle)
+    view_id, pass_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), true, pipeline, res, frame_buffer.handle)
 
     -- Draw a plabe using the texture the scene was rendered to
     hg.SetViewPerspective(view_id, 0, 0, res_x, res_y, hg.TranslationMat4(hg.Vec3(0, 0, -1.8)))

--- a/scene_capture_texture.py
+++ b/scene_capture_texture.py
@@ -47,19 +47,20 @@ state = "none"
 while not hg.ReadKeyboard().Key(hg.K_Escape) and hg.IsWindowOpen(win):
     dt = hg.TickClock()
 
+    #Update Scene and render to the frameBuffer
     scene.Update(dt)
 
     trs = scene.GetNode("engine_master").GetTransform()
     trs.SetRot(trs.GetRot() + hg.Vec3(0, hg.Deg(15) * hg.time_to_sec_f(dt), 0))
 
     view_id = 0
-    view_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), True, pipeline, res, frame_buffer.handle)
+    view_id, pass_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), True, pipeline, res, frame_buffer.handle)
 
     #Draw a plabe using the texture the scene was rendered to
-    hg.SetViewPerspective(view_id   , 0, 0, res_x, res_y, hg.TranslationMat4(hg.Vec3(0, 0, -1.8)))
+    hg.SetViewPerspective(view_id, 0, 0, res_x, res_y, hg.TranslationMat4(hg.Vec3(0, 0, -1.8)))
 
-    val_uniforms = {hg.MakeUniformSetValue('color', hg.Vec4(1, 1, 1, 1))}
-    tex_uniforms = {hg.MakeUniformSetTexture('s_tex', tex_color, 0)}
+    val_uniforms = [hg.MakeUniformSetValue('color', hg.Vec4(1, 1, 1, 1))]
+    tex_uniforms = [hg.MakeUniformSetTexture('s_tex', tex_color, 0)]
 
     hg.DrawModel(view_id, plane_mdl, plane_prg, val_uniforms, tex_uniforms,
         hg.TransformationMat4(hg.Vec3(0, 0, 0), hg.Vec3(math.pi / 2, 0, math.pi)))

--- a/scene_capture_texture.py
+++ b/scene_capture_texture.py
@@ -9,7 +9,7 @@ hg.InputInit()
 hg.WindowSystemInit()
 
 res_x, res_y, tex_size = 1024, 1024, 1024
-win = hg.RenderInit('Scene Capture Texture', res_x, res_y, hg.RF_VSync | hg.RF_MSAA4X)
+win = hg.RenderInit('Scene Capture Texture - Press SpaceBar to capture', res_x, res_y, hg.RF_VSync | hg.RF_MSAA4X)
 
 
 #Link precompiled assets folder to the project

--- a/scene_capture_texture.py
+++ b/scene_capture_texture.py
@@ -1,0 +1,83 @@
+# Toyota 2JZ-GTE Engine model by Serhii Denysenko (CGTrader: serhiidenysenko8256)
+# URL : https://www.cgtrader.com/3d-models/vehicle/part/toyota-2jz-gte-engine-2932b715-2f42-4ecd-93ce-df9507c67ce8
+
+
+import harfang as hg
+import math
+
+hg.InputInit()
+hg.WindowSystemInit()
+
+res_x, res_y, tex_size = 1024, 1024, 1024
+win = hg.RenderInit('Scene Capture Texture', res_x, res_y, hg.RF_VSync | hg.RF_MSAA4X)
+
+
+#Link precompiled assets folder to the project
+hg.AddAssetsFolder("resources_compiled")
+
+#Create Pipeline
+pipeline = hg.CreateForwardPipeline()
+res = hg.PipelineResources()
+
+#Create a 1024*1024 frame buffer to draw the scene to
+frame_buffer = hg.CreateFrameBuffer(tex_size, tex_size, hg.TF_RGBA8, hg.TF_D24, 4, 'framebuffer')
+tex_color = hg.GetColorTexture(frame_buffer)
+
+#Prepare screenshot requirements
+tex_color_ref = res.AddTexture("tex_rb", tex_color)
+tex_readback = hg.CreateTexture(tex_size, tex_size, "readback", hg.TF_ReadBack | hg.TF_BlitDestination, hg.TF_RGBA8)
+picture = hg.Picture(tex_size, tex_size, hg.PF_RGBA32)
+
+#Load scene
+scene = hg.Scene()
+ret = hg.LoadSceneFromAssets("car_engine/engine.scn", scene, res, hg.GetForwardPipelineInfo())
+
+#Create the plane model
+vtx_layout = hg.VertexLayoutPosFloatTexCoord0UInt8()
+plane_mdl = hg.CreatePlaneModel(vtx_layout, 1, 1, 1, 1)
+plane_ref = res.AddModel('plane', plane_mdl)
+
+#Prepare the plane shader program
+plane_prg = hg.LoadProgramFromAssets('shaders/texture')
+
+#Main Loop 
+frame = 0
+state = "none"
+
+while not hg.ReadKeyboard().Key(hg.K_Escape) and hg.IsWindowOpen(win):
+    dt = hg.TickClock()
+
+    scene.Update(dt)
+
+    trs = scene.GetNode("engine_master").GetTransform()
+    trs.SetRot(trs.GetRot() + hg.Vec3(0, hg.Deg(15) * hg.time_to_sec_f(dt), 0))
+
+    view_id = 0
+    view_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), True, pipeline, res, frame_buffer.handle)
+
+    #Draw a plabe using the texture the scene was rendered to
+    hg.SetViewPerspective(view_id   , 0, 0, res_x, res_y, hg.TranslationMat4(hg.Vec3(0, 0, -1.8)))
+
+    val_uniforms = {hg.MakeUniformSetValue('color', hg.Vec4(1, 1, 1, 1))}
+    tex_uniforms = {hg.MakeUniformSetTexture('s_tex', tex_color, 0)}
+
+    hg.DrawModel(view_id, plane_mdl, plane_prg, val_uniforms, tex_uniforms,
+        hg.TransformationMat4(hg.Vec3(0, 0, 0), hg.Vec3(math.pi / 2, 0, math.pi)))
+    
+    # Change state to capture when user press Space and Capture is not already running
+    if (hg.ReadKeyboard().Key(hg.K_Space) and state == "none"):
+        state = "capture"
+        frame_count_capture, view_id = hg.CaptureTexture(view_id, res, tex_color_ref, tex_readback, picture)
+
+    # Take screenshot if CaptureTexture is ready and user pressed space
+    elif(state == "capture" and frame_count_capture <= frame):
+        png_filename = "screenshots/" + ".png"
+        hg.SavePNG(picture, png_filename)
+        state = "none" #Reset state to none to be able to screenshot again
+
+    #
+    frame = hg.Frame()
+    hg.UpdateWindow(win)
+
+hg.RenderShutdown()
+hg.DestroyWindow(win)

--- a/scene_screenshot_buffer.lua
+++ b/scene_screenshot_buffer.lua
@@ -7,26 +7,28 @@ hg.InputInit()
 hg.WindowSystemInit()
 
 res_x, res_y = 1024, 1024
-win = hg.RenderInit('Screenshot Buffer', res_x, res_y, hg.RF_VSync | hg.RF_MSAA4X)
+win = hg.RenderInit('Frame Buffer Screenshot', res_x, res_y, hg.RF_VSync | hg.RF_MSAA4X)
 
-hg.AddAssetsFolder("resources_compiled")
 
 pipeline = hg.CreateForwardPipeline()
 local res = hg.PipelineResources()
 
-scene = hg.Scene()
-hg.LoadSceneFromAssets("car_engine/engine.scn", scene, res, hg.GetForwardPipelineInfo())
+hg.AddAssetsFolder("resources_compiled")
 
 local tex_size = 1024
-local picture = hg.Picture(tex_size, tex_size, hg.PF_RGBA32F)
+local picture = hg.Picture(tex_size, tex_size, hg.PF_RGBA32)
 local frame_buffer = hg.CreateFrameBuffer(tex_size, tex_size, hg.TF_RGBA8, hg.TF_D24, 4, 'framebuffer')
 local tex_color = hg.GetColorTexture(frame_buffer)
 local tex_color_ref = res:AddTexture("tex_rb", tex_color)
 local tex_readback = hg.CreateTexture(tex_size, tex_size, "readback", hg.TF_ReadBack | hg.TF_BlitDestination, hg.TF_RGBA8)
 
+scene = hg.Scene()
+ret = hg.LoadSceneFromAssets("car_engine/engine.scn", scene, res, hg.GetForwardPipelineInfo())
+
+assert(ret)
+
 local state = "none"
 
--- main loop
 local frame = 0
 local view_id = 0
 
@@ -57,16 +59,16 @@ while not hg.ReadKeyboard():Key(hg.K_Escape) and hg.IsWindowOpen(win) do
 
 	scene:Update(dt)
 
-	view_id = 0
+    view_id = 0
 	view_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), true, pipeline, res, frame_buffer.handle)
-	--view_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), true, pipeline, res)
 
-	-- hg.SetViewPerspective(view_id, 0, 0, res_x, res_y, hg.TranslationMat4(hg.Vec3(0, 0, -1.8)))
+	hg.SetViewPerspective(view_id, 0, 0, res_x, res_y, hg.TranslationMat4(hg.Vec3(0, 0, -1.8)))
 
-	-- val_uniforms = {hg.MakeUniformSetValue('color', hg.Vec4(1, 1, 1, 1))} 
-	-- tex_uniforms = {hg.MakeUniformSetTexture('s_tex', tex_color, 0)}
+	val_uniforms = {hg.MakeUniformSetValue('color', hg.Vec4(1, 1, 1, 1))} 
+	tex_uniforms = {hg.MakeUniformSetTexture('s_tex', tex_color, 0)}
 
-	-- hg.DrawModel(view_id, plane_mdl, plane_prg, val_uniforms, tex_uniforms, hg.TransformationMat4(hg.Vec3(0, 0, 0), hg.Vec3(-math.pi/2,0, 0)))
+	hg.DrawModel(view_id, plane_mdl, plane_prg, val_uniforms, tex_uniforms, hg.TransformationMat4(hg.Vec3(0, 0, 0), hg.Vec3(-math.pi/2,0, 0)))
+
 	frame = hg.Frame()
 	hg.UpdateWindow(win)
 end

--- a/scene_screenshot_buffer.lua
+++ b/scene_screenshot_buffer.lua
@@ -5,64 +5,73 @@ hg = require("harfang")
 hg.InputInit()
 hg.WindowSystemInit()
 
-res_x, res_y = 1024, 1024
+local res_x, res_y, tex_size = 1024, 1024, 1024
 win = hg.RenderInit('Frame Buffer Screenshot', res_x, res_y, hg.RF_VSync | hg.RF_MSAA4X)
 
+--Link precompiled assets folder to the project
+hg.AddAssetsFolder("resources_compiled")
 
+--Create Pipeline
 pipeline = hg.CreateForwardPipeline()
 local res = hg.PipelineResources()
 
-hg.AddAssetsFolder("resources_compiled")
-
-local tex_size = 1024
-local picture = hg.Picture(tex_size, tex_size, hg.PF_RGBA32)
+--Create a 1024*1024 frame buffer to draw the scene to
 local frame_buffer = hg.CreateFrameBuffer(tex_size, tex_size, hg.TF_RGBA8, hg.TF_D24, 4, 'framebuffer')
 local tex_color = hg.GetColorTexture(frame_buffer)
+
+--Prepare screenshot requirements
 local tex_color_ref = res:AddTexture("tex_rb", tex_color)
 local tex_readback = hg.CreateTexture(tex_size, tex_size, "readback", hg.TF_ReadBack | hg.TF_BlitDestination, hg.TF_RGBA8)
+local picture = hg.Picture(tex_size, tex_size, hg.PF_RGBA32)
 
+--Load scene
 scene = hg.Scene()
 ret = hg.LoadSceneFromAssets("car_engine/engine.scn", scene, res, hg.GetForwardPipelineInfo())
 
-local state = "none"
-
-local frame = 0
-local view_id = 0
-
+--Create the plane model
 vtx_layout = hg.VertexLayoutPosFloatTexCoord0UInt8()
-
 plane_mdl = hg.CreatePlaneModel(vtx_layout, 1, 1, 1, 1)
 plane_ref = res:AddModel('plane', plane_mdl)
 
+--Prepare the plane shader program
 plane_prg = hg.LoadProgramFromAssets('shaders/texture')
 
+--Main Loop 
+local frame = 0
+local view_id = 0
+local state = "none"
 
 while not hg.ReadKeyboard():Key(hg.K_Escape) and hg.IsWindowOpen(win) do
 	dt = hg.TickClock()
 
+    --Change state to capture when user press Space and Capture is not already running
     if(hg.ReadKeyboard():Key(hg.K_Space) and state == "none") then
         state = "capture"
         frame_count_capture, view_id = hg.CaptureTexture(view_id, res, tex_color_ref, tex_readback, picture)
         print(frame_count_capture, frame) 
 
+    --Take screenshot if CaptureTexture is ready and user pressed space
     elseif(state == "capture" and frame_count_capture <= frame) then
         local png_filename = "screenshots/" .. ".png"
         hg.SavePNG(picture, png_filename)
-        state = "none"
+        state = "none" --Reset state to none to be able to screenshot again
     end
 
+    --Update Scene and render to the frameBuffer
 	scene:Update(dt)
 
     view_id = 0
 	view_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), true, pipeline, res, frame_buffer.handle)
 	
+    --Draw a plabe using the texture the scene was rendered to
 	hg.SetViewPerspective(view_id, 0, 0, res_x, res_y, hg.TranslationMat4(hg.Vec3(0, 0, -1.8)))
 	
 	val_uniforms = {hg.MakeUniformSetValue('color', hg.Vec4(1, 1, 1, 1))} 
 	tex_uniforms = {hg.MakeUniformSetTexture('s_tex', tex_color, 0)}
 	
 	hg.DrawModel(view_id, plane_mdl, plane_prg, val_uniforms, tex_uniforms, hg.TransformationMat4(hg.Vec3(0, 0, 0), hg.Vec3(math.pi / 2, 0, math.pi)))
-
+    
+    --
 	frame = hg.Frame()
 	hg.UpdateWindow(win)
 end

--- a/scene_screenshot_buffer.lua
+++ b/scene_screenshot_buffer.lua
@@ -1,0 +1,78 @@
+-- Toyota 2JZ-GTE Engine model by Serhii Denysenko (CGTrader: serhiidenysenko8256)
+-- URL : https://www.cgtrader.com/3d-models/vehicle/part/toyota-2jz-gte-engine-2932b715-2f42-4ecd-93ce-df9507c67ce8
+
+hg = require("harfang")
+
+hg.InputInit()
+hg.WindowSystemInit()
+
+res_x, res_y = 1024, 1024
+win = hg.RenderInit('Screenshot Buffer', res_x, res_y, hg.RF_VSync | hg.RF_MSAA4X)
+
+hg.AddAssetsFolder("resources_compiled")
+
+pipeline = hg.CreateForwardPipeline()
+local res = hg.PipelineResources()
+
+scene = hg.Scene()
+hg.LoadSceneFromAssets("car_engine/engine.scn", scene, res, hg.GetForwardPipelineInfo())
+
+local tex_size = 1024
+local picture = hg.Picture(tex_size, tex_size, hg.PF_RGBA32F)
+local frame_buffer = hg.CreateFrameBuffer(tex_size, tex_size, hg.TF_RGBA8, hg.TF_D24, 4, 'framebuffer')
+local tex_color = hg.GetColorTexture(frame_buffer)
+local tex_color_ref = res:AddTexture("tex_rb", tex_color)
+local tex_readback = hg.CreateTexture(tex_size, tex_size, "readback", hg.TF_ReadBack | hg.TF_BlitDestination, hg.TF_RGBA8)
+
+local state = "none"
+
+-- main loop
+local frame = 0
+local view_id = 0
+
+vtx_layout = hg.VertexLayoutPosFloatTexCoord0UInt8()
+
+plane_mdl = hg.CreatePlaneModel(vtx_layout, 1, 1, 1, 1)
+plane_ref = res:AddModel('plane', plane_mdl)
+
+plane_prg = hg.LoadProgramFromAssets('shaders/texture')
+
+
+while not hg.ReadKeyboard():Key(hg.K_Escape) and hg.IsWindowOpen(win) do
+	dt = hg.TickClock()
+
+	trs = scene:GetNode('engine_master'):GetTransform()
+	trs:SetRot(trs:GetRot() + hg.Vec3(0, hg.Deg(15) * hg.time_to_sec_f(dt), 0))
+
+    if(hg.ReadKeyboard():Key(hg.K_Space) and state == "none") then
+        state = "capture"
+        frame_count_capture, view_id = hg.CaptureTexture(view_id, res, tex_color_ref, tex_readback, picture)
+        print(frame_count_capture, frame) 
+
+    elseif(state == "capture" and frame_count_capture <= frame) then
+        local png_filename = "screenshots/" .. ".png"
+        hg.SavePNG(picture, png_filename)
+        state = "none"
+    end
+
+	scene:Update(dt)
+
+	view_id = 0
+	view_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), true, pipeline, res, frame_buffer.handle)
+	--view_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), true, pipeline, res)
+
+	-- hg.SetViewPerspective(view_id, 0, 0, res_x, res_y, hg.TranslationMat4(hg.Vec3(0, 0, -1.8)))
+
+	-- val_uniforms = {hg.MakeUniformSetValue('color', hg.Vec4(1, 1, 1, 1))} 
+	-- tex_uniforms = {hg.MakeUniformSetTexture('s_tex', tex_color, 0)}
+
+	-- hg.DrawModel(view_id, plane_mdl, plane_prg, val_uniforms, tex_uniforms, hg.TransformationMat4(hg.Vec3(0, 0, 0), hg.Vec3(-math.pi/2,0, 0)))
+	frame = hg.Frame()
+	hg.UpdateWindow(win)
+end
+
+hg.RenderShutdown()
+hg.DestroyWindow(win)
+
+
+  

--- a/scene_screenshot_buffer.lua
+++ b/scene_screenshot_buffer.lua
@@ -2,7 +2,6 @@
 -- URL : https://www.cgtrader.com/3d-models/vehicle/part/toyota-2jz-gte-engine-2932b715-2f42-4ecd-93ce-df9507c67ce8
 
 hg = require("harfang")
-
 hg.InputInit()
 hg.WindowSystemInit()
 
@@ -25,8 +24,6 @@ local tex_readback = hg.CreateTexture(tex_size, tex_size, "readback", hg.TF_Read
 scene = hg.Scene()
 ret = hg.LoadSceneFromAssets("car_engine/engine.scn", scene, res, hg.GetForwardPipelineInfo())
 
-assert(ret)
-
 local state = "none"
 
 local frame = 0
@@ -43,9 +40,6 @@ plane_prg = hg.LoadProgramFromAssets('shaders/texture')
 while not hg.ReadKeyboard():Key(hg.K_Escape) and hg.IsWindowOpen(win) do
 	dt = hg.TickClock()
 
-	trs = scene:GetNode('engine_master'):GetTransform()
-	trs:SetRot(trs:GetRot() + hg.Vec3(0, hg.Deg(15) * hg.time_to_sec_f(dt), 0))
-
     if(hg.ReadKeyboard():Key(hg.K_Space) and state == "none") then
         state = "capture"
         frame_count_capture, view_id = hg.CaptureTexture(view_id, res, tex_color_ref, tex_readback, picture)
@@ -61,13 +55,13 @@ while not hg.ReadKeyboard():Key(hg.K_Escape) and hg.IsWindowOpen(win) do
 
     view_id = 0
 	view_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), true, pipeline, res, frame_buffer.handle)
-
+	
 	hg.SetViewPerspective(view_id, 0, 0, res_x, res_y, hg.TranslationMat4(hg.Vec3(0, 0, -1.8)))
-
+	
 	val_uniforms = {hg.MakeUniformSetValue('color', hg.Vec4(1, 1, 1, 1))} 
 	tex_uniforms = {hg.MakeUniformSetTexture('s_tex', tex_color, 0)}
-
-	hg.DrawModel(view_id, plane_mdl, plane_prg, val_uniforms, tex_uniforms, hg.TransformationMat4(hg.Vec3(0, 0, 0), hg.Vec3(-math.pi/2,0, 0)))
+	
+	hg.DrawModel(view_id, plane_mdl, plane_prg, val_uniforms, tex_uniforms, hg.TransformationMat4(hg.Vec3(0, 0, 0), hg.Vec3(math.pi / 2, 0, math.pi)))
 
 	frame = hg.Frame()
 	hg.UpdateWindow(win)

--- a/scene_screenshot_buffer.lua
+++ b/scene_screenshot_buffer.lua
@@ -42,9 +42,23 @@ state = "none"
 while not hg.ReadKeyboard():Key(hg.K_Escape) and hg.IsWindowOpen(win) do
     dt = hg.TickClock()
 
+    -- Update Scene and render to the frameBuffer
+    scene:Update(dt)
+
+    trs = scene:GetNode('engine_master'):GetTransform()
+	trs:SetRot(trs:GetRot() + hg.Vec3(0, hg.Deg(15) * hg.time_to_sec_f(dt), 0))
+
     view_id = 0
-    view_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), true, pipeline, res,
-        frame_buffer.handle)
+    view_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), true, pipeline, res, frame_buffer.handle)
+
+    -- Draw a plabe using the texture the scene was rendered to
+    hg.SetViewPerspective(view_id, 0, 0, res_x, res_y, hg.TranslationMat4(hg.Vec3(0, 0, -1.8)))
+
+    val_uniforms = {hg.MakeUniformSetValue('color', hg.Vec4(1, 1, 1, 1))}
+    tex_uniforms = {hg.MakeUniformSetTexture('s_tex', tex_color, 0)}
+
+    hg.DrawModel(view_id, plane_mdl, plane_prg, val_uniforms, tex_uniforms,
+        hg.TransformationMat4(hg.Vec3(0, 0, 0), hg.Vec3(math.pi / 2, 0, math.pi)))
 
     -- Change state to capture when user press Space and Capture is not already running
     if (hg.ReadKeyboard():Key(hg.K_Space) and state == "none") then
@@ -57,18 +71,6 @@ while not hg.ReadKeyboard():Key(hg.K_Escape) and hg.IsWindowOpen(win) do
         hg.SavePNG(picture, png_filename)
         state = "none" -- Reset state to none to be able to screenshot again
     end
-
-    -- Update Scene and render to the frameBuffer
-    scene:Update(dt)
-
-    -- Draw a plabe using the texture the scene was rendered to
-    hg.SetViewPerspective(view_id, 0, 0, res_x, res_y, hg.TranslationMat4(hg.Vec3(0, 0, -1.8)))
-
-    val_uniforms = {hg.MakeUniformSetValue('color', hg.Vec4(1, 1, 1, 1))}
-    tex_uniforms = {hg.MakeUniformSetTexture('s_tex', tex_color, 0)}
-
-    hg.DrawModel(view_id, plane_mdl, plane_prg, val_uniforms, tex_uniforms,
-        hg.TransformationMat4(hg.Vec3(0, 0, 0), hg.Vec3(math.pi / 2, 0, math.pi)))
 
     --
     frame = hg.Frame()

--- a/scene_screenshot_buffer.lua
+++ b/scene_screenshot_buffer.lua
@@ -1,83 +1,80 @@
 -- Toyota 2JZ-GTE Engine model by Serhii Denysenko (CGTrader: serhiidenysenko8256)
 -- URL : https://www.cgtrader.com/3d-models/vehicle/part/toyota-2jz-gte-engine-2932b715-2f42-4ecd-93ce-df9507c67ce8
-
 hg = require("harfang")
 hg.InputInit()
 hg.WindowSystemInit()
 
-local res_x, res_y, tex_size = 1024, 1024, 1024
+res_x, res_y, tex_size = 1024, 1024, 1024
 win = hg.RenderInit('Frame Buffer Screenshot', res_x, res_y, hg.RF_VSync | hg.RF_MSAA4X)
 
---Link precompiled assets folder to the project
+-- Link precompiled assets folder to the project
 hg.AddAssetsFolder("resources_compiled")
 
---Create Pipeline
+-- Create Pipeline
 pipeline = hg.CreateForwardPipeline()
-local res = hg.PipelineResources()
+res = hg.PipelineResources()
 
---Create a 1024*1024 frame buffer to draw the scene to
-local frame_buffer = hg.CreateFrameBuffer(tex_size, tex_size, hg.TF_RGBA8, hg.TF_D24, 4, 'framebuffer')
-local tex_color = hg.GetColorTexture(frame_buffer)
+-- Create a 1024*1024 frame buffer to draw the scene to
+frame_buffer = hg.CreateFrameBuffer(tex_size, tex_size, hg.TF_RGBA8, hg.TF_D24, 4, 'framebuffer')
+tex_color = hg.GetColorTexture(frame_buffer)
 
---Prepare screenshot requirements
-local tex_color_ref = res:AddTexture("tex_rb", tex_color)
-local tex_readback = hg.CreateTexture(tex_size, tex_size, "readback", hg.TF_ReadBack | hg.TF_BlitDestination, hg.TF_RGBA8)
-local picture = hg.Picture(tex_size, tex_size, hg.PF_RGBA32)
+-- Prepare screenshot requirements
+tex_color_ref = res:AddTexture("tex_rb", tex_color)
+tex_readback = hg.CreateTexture(tex_size, tex_size, "readback", hg.TF_ReadBack | hg.TF_BlitDestination, hg.TF_RGBA8)
+picture = hg.Picture(tex_size, tex_size, hg.PF_RGBA32)
 
---Load scene
+-- Load scene
 scene = hg.Scene()
 ret = hg.LoadSceneFromAssets("car_engine/engine.scn", scene, res, hg.GetForwardPipelineInfo())
 
---Create the plane model
+-- Create the plane model
 vtx_layout = hg.VertexLayoutPosFloatTexCoord0UInt8()
 plane_mdl = hg.CreatePlaneModel(vtx_layout, 1, 1, 1, 1)
 plane_ref = res:AddModel('plane', plane_mdl)
 
---Prepare the plane shader program
+-- Prepare the plane shader program
 plane_prg = hg.LoadProgramFromAssets('shaders/texture')
 
---Main Loop 
-local frame = 0
-local view_id = 0
-local state = "none"
+-- Main Loop 
+frame = 0
+state = "none"
 
 while not hg.ReadKeyboard():Key(hg.K_Escape) and hg.IsWindowOpen(win) do
-	dt = hg.TickClock()
-
-    --Change state to capture when user press Space and Capture is not already running
-    if(hg.ReadKeyboard():Key(hg.K_Space) and state == "none") then
-        state = "capture"
-        frame_count_capture, view_id = hg.CaptureTexture(view_id, res, tex_color_ref, tex_readback, picture)
-        print(frame_count_capture, frame) 
-
-    --Take screenshot if CaptureTexture is ready and user pressed space
-    elseif(state == "capture" and frame_count_capture <= frame) then
-        local png_filename = "screenshots/" .. ".png"
-        hg.SavePNG(picture, png_filename)
-        state = "none" --Reset state to none to be able to screenshot again
-    end
-
-    --Update Scene and render to the frameBuffer
-	scene:Update(dt)
+    dt = hg.TickClock()
 
     view_id = 0
-	view_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), true, pipeline, res, frame_buffer.handle)
-	
-    --Draw a plabe using the texture the scene was rendered to
-	hg.SetViewPerspective(view_id, 0, 0, res_x, res_y, hg.TranslationMat4(hg.Vec3(0, 0, -1.8)))
-	
-	val_uniforms = {hg.MakeUniformSetValue('color', hg.Vec4(1, 1, 1, 1))} 
-	tex_uniforms = {hg.MakeUniformSetTexture('s_tex', tex_color, 0)}
-	
-	hg.DrawModel(view_id, plane_mdl, plane_prg, val_uniforms, tex_uniforms, hg.TransformationMat4(hg.Vec3(0, 0, 0), hg.Vec3(math.pi / 2, 0, math.pi)))
-    
+    view_id = hg.SubmitSceneToPipeline(view_id, scene, hg.IntRect(0, 0, res_x, res_y), true, pipeline, res,
+        frame_buffer.handle)
+
+    -- Change state to capture when user press Space and Capture is not already running
+    if (hg.ReadKeyboard():Key(hg.K_Space) and state == "none") then
+        state = "capture"
+        frame_count_capture, view_id = hg.CaptureTexture(view_id, res, tex_color_ref, tex_readback, picture)
+
+        -- Take screenshot if CaptureTexture is ready and user pressed space
+    elseif (state == "capture" and frame_count_capture <= frame) then
+        png_filename = "screenshots/" .. ".png"
+        hg.SavePNG(picture, png_filename)
+        state = "none" -- Reset state to none to be able to screenshot again
+    end
+
+    -- Update Scene and render to the frameBuffer
+    scene:Update(dt)
+
+    -- Draw a plabe using the texture the scene was rendered to
+    hg.SetViewPerspective(view_id, 0, 0, res_x, res_y, hg.TranslationMat4(hg.Vec3(0, 0, -1.8)))
+
+    val_uniforms = {hg.MakeUniformSetValue('color', hg.Vec4(1, 1, 1, 1))}
+    tex_uniforms = {hg.MakeUniformSetTexture('s_tex', tex_color, 0)}
+
+    hg.DrawModel(view_id, plane_mdl, plane_prg, val_uniforms, tex_uniforms,
+        hg.TransformationMat4(hg.Vec3(0, 0, 0), hg.Vec3(math.pi / 2, 0, math.pi)))
+
     --
-	frame = hg.Frame()
-	hg.UpdateWindow(win)
+    frame = hg.Frame()
+    hg.UpdateWindow(win)
 end
 
 hg.RenderShutdown()
 hg.DestroyWindow(win)
 
-
-  


### PR DESCRIPTION
Ce script permet de capturer et de sauvegarder des captures d'écran d'un modèle 3D du moteur Toyota 2JZ-GTE. Le script rend la scène dans un framebuffer, puis capture une image à la demande en appuyant sur la touche "Espace". La capture est ensuite sauvegardée au format PNG dans le répertoire screenshots.